### PR TITLE
(analyzer): Fix max survivor threshold for a given time limit

### DIFF
--- a/src/analyze.py
+++ b/src/analyze.py
@@ -1,20 +1,18 @@
 import subprocess
 import os
 import traceback
-
+import time
 from src.report import generate_report
 
-
-# False == mutant killed
 def run(command, timeout=10000):
     try:
         subprocess.run(command, check=True, stdout=subprocess.PIPE,
-                       stderr=subprocess.PIPE, text=False, shell=True,
-                       timeout=timeout)
+                      stderr=subprocess.PIPE, text=False, shell=True,
+                      timeout=timeout)
         return True
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return False
-    
+
 def get_command_to_kill(target_file_path, jobs):
     build_command = "cmake --build build"
     if jobs != 0:
@@ -29,58 +27,77 @@ def get_command_to_kill(target_file_path, jobs):
         command = f"{build_command} && ./build/src/test/test_bitcoin && CI_FAILFAST_TEST_LEAVE_DANGLING=1 ./build/test/functional/test_runner.py -F"
     return command
 
-def analyze(folder_path, command="", jobs=0, timeout=1000):
+def analyze(folder_path, command="", jobs=0, timeout=10000, survival_threshold=0.3):
+    """
+    Analyze mutants with early termination if too many survive.
+    
+    Args:
+        folder_path: Path to mutants folder
+        command: Test command to run
+        jobs: Number of parallel jobs
+        timeout: Maximum execution time per mutant
+        survival_threshold: Maximum acceptable survival rate (0.3 = 30%)
+    """
     killed = []
     not_killed = []
-
-    with open(os.path.join(folder_path, 'original_file.txt'), 'r') as file:
-        target_file_path = file.readline()
-
-    if command == "":
-        build_command = "rm -rf build && cmake -B build && cmake --build build"
-        print(f"\n\nRunning {build_command}")
-        run(build_command)
-        command = get_command_to_kill(target_file_path, jobs)
+    start_time = time.time()
 
     try:
-        # Get list of files in the folder
+        # Read target file path
+        with open(os.path.join(folder_path, 'original_file.txt'), 'r') as file:
+            target_file_path = file.readline()
+
+        # Setup command if not provided
+        if command == "":
+            build_command = "rm -rf build && cmake -B build && cmake --build build"
+            print(f"\n\nRunning {build_command}")
+            run(build_command)
+            command = get_command_to_kill(target_file_path, jobs)
+
+        # Get list of mutant files
         files = [f for f in os.listdir(folder_path)
-                 if os.path.isfile(os.path.join(folder_path, f))]
+                if os.path.isfile(os.path.join(folder_path, f)) and not f.endswith('.txt')]
+        
+        total_mutants = len(files)
+        print(f"* {total_mutants} MUTANTS *")
 
-        # Loop through each file in the folder
-        len_files = len(files)
-        print(f"* {len(files)-1} MUTANTS *")
-        i = 0
-        for file_name in files:
-            if '.txt' in file_name:
-                continue
-            print(f"[{i+1}/{len_files-1}] Analyzing {file_name}")
-            # Construct the full file path
-            file_path = os.path.join(folder_path, file_name)
+        if total_mutants == 0: raise Exception(f'No mutants on the provided folder path ({folder_path})')
+        else:
+            for i, file_name in enumerate(files, 1):
+                current_time = time.time() - start_time
 
-            # Read the content of the current file
-            with open(file_path, 'r') as file:
-                content = file.read()
+                current_survival_rate = len(not_killed) / (total_mutants)
+                if current_survival_rate > survival_threshold:
+                    print(f"\nTerminating early: {current_survival_rate:.2%} mutants surviving after {i} iterations")
+                    print(f"Survival rate exceeds threshold of {survival_threshold:.0%}")
+                    break
+                if current_time >= timeout:
+                    print(f"\nTerminating early: execution time exceeded timeout of {timeout:.2}s")
+                    break
+                print(f"[{i}/{total_mutants}] Analyzing {file_name}")
+                file_path = os.path.join(folder_path, file_name)
 
-            # Replace the content of the target file
-            with open(target_file_path, 'w') as target_file:
-                target_file.write(content)
+                # Read and apply mutant
+                with open(file_path, 'r') as file:
+                    content = file.read()
+                with open(target_file_path, 'w') as target_file:
+                    target_file.write(content)
 
-            print(f"Running: {command}")
-            result = run(command, timeout)
-            if result:
-                print("NOT KILLED ❌")
-                not_killed.append(file_name)
-            else:
-                print("KILLED ✅")
-                killed.append(file_name)
-            i += 1
+                print(f"Running: {command}")
+                result = run(command, timeout)
+                if result:
+                    print("NOT KILLED ❌")
+                    not_killed.append(file_name)
+                else:
+                    print("KILLED ✅")
+                    killed.append(file_name)
 
+            # Always generate report with current results
+            score = len(killed) / total_mutants
+            print(f"\nMUTATION SCORE: {round(score * 100, 2)}%")
+            generate_report(not_killed, folder_path, target_file_path, score)
     except Exception as e:
         traceback.print_exc()
         print(f"An error occurred: {e}")
-
-    score = len(killed) / (len(killed) + len(not_killed))
-    print(f"\nMUTATION SCORE: {round(score * 100, 2)}%\n")
-    generate_report(not_killed, folder_path, target_file_path, score)
+        raise
     return killed, not_killed

--- a/src/mutation_core.py
+++ b/src/mutation_core.py
@@ -83,6 +83,8 @@ def main():
                                help="Number of jobs to be used to compile Bitcoin Core")
     parser_analyze.add_argument('-c', '--command', dest="command", default="", type=str,
                                help="Command to test the mutants (e.g. cmake --build build && ./build/test/functional/test.py)")
+    parser_analyze.add_argument('-st', '--survival-threshold', dest="survival_threshold", default=0.3, type=float,
+                               help="Maximum acceptable survival rate (0.3 = 30%)")
 
     args = parser.parse_args()
     if args.subcommand is None:
@@ -115,9 +117,9 @@ def main():
                     if folder.startswith("muts"):
                         folders_starting_with_muts.append(os.path.join(root, folder))
             for folder in folders_starting_with_muts:
-                analyze(folder_path=folder, command=args.command, jobs=args.jobs, timeout=args.timeout)
+                analyze(folder_path=folder, command=args.command, jobs=args.jobs, timeout=args.timeout, survival_threshold=args.survival_threshold)
         else:
-            analyze(folder_path=args.folder, command=args.command, jobs=args.jobs, timeout=args.timeout)
+            analyze(folder_path=args.folder, command=args.command, jobs=args.jobs, timeout=args.timeout, survival_threshold=args.survival_threshold)
     else:
         parser.print_help()
         sys.exit("No command provided.")

--- a/src/mutation_core.py
+++ b/src/mutation_core.py
@@ -83,7 +83,7 @@ def main():
                                help="Number of jobs to be used to compile Bitcoin Core")
     parser_analyze.add_argument('-c', '--command', dest="command", default="", type=str,
                                help="Command to test the mutants (e.g. cmake --build build && ./build/test/functional/test.py)")
-    parser_analyze.add_argument('-st', '--survival-threshold', dest="survival_threshold", default=0.3, type=float,
+    parser_analyze.add_argument('-st', '--survival-threshold', dest="survival_threshold", default=0.75, type=float,
                                help="Maximum acceptable survival rate (0.3 = 30%)")
 
     args = parser.parse_args()

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,11 +1,9 @@
 import unittest
+import tempfile
 import os
-import sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
+import shutil
+from src.analyze import analyze
 from src.analyze import get_command_to_kill
-
 class TestAnalyze(unittest.TestCase):
     def test_get_command_to_kill(self):
         files_and_command = {
@@ -15,7 +13,97 @@ class TestAnalyze(unittest.TestCase):
         }
         for files, command in files_and_command.items():
             self.assertEqual(get_command_to_kill(files, jobs=0), command)
+    def setUp(self):
+        """Set up test environment with temporary directory and files"""
+        self.test_dir = tempfile.mkdtemp()
+        
+        # Create original_file.txt with target path
+        self.target_file_path = os.path.join(self.test_dir, "test/functional/feature_addrman.py")
+        with open(os.path.join(self.test_dir, "original_file.txt"), "w") as f:
+            f.write(self.target_file_path)
+        
+        # Create directory structure if needed
+        os.makedirs(os.path.dirname(self.target_file_path), exist_ok=True)
+        
+        # Create mock target file
+        with open(self.target_file_path, "w") as f:
+            f.write("# Original content")
 
+    def tearDown(self):
+        """Clean up test environment"""
+        shutil.rmtree(self.test_dir)
+
+    def test_normal_execution(self):
+        """Test normal execution where mutants are analyzed"""
+        # Create test mutant files
+        mutant_contents = {
+            "mutant1.py": "# Mutant 1 content",
+            "mutant2.py": "# Mutant 2 content",
+            "mutant3.py": "# Mutant 3 content",
+            "mutant4.py": "# Mutant 4 content",
+            "mutant5.py": "# Mutant 5 content",
+            "mutant6.py": "# Mutant 6 content",
+            "mutant7.py": "# Mutant 7 content",
+            "mutant8.py": "# Mutant 8 content",
+            "mutant9.py": "# Mutant 9 content",
+            "mutant10.py": "# Mutant 10 content"
+        }
+        
+        for name, content in mutant_contents.items():
+            with open(os.path.join(self.test_dir, name), "w") as f:
+                f.write(content)
+
+        # Run analysis with a simple command that always "kills" mutants
+        killed, not_killed = analyze(
+            self.test_dir,
+            command="exit 1",  # Command that always fails, thus "killing" mutants
+            timeout=10,
+            survival_threshold=0.3
+        )
+        
+        self.assertEqual(len(killed), 10)
+        self.assertEqual(len(not_killed), 0)
+
+    def test_early_termination(self):
+        """Test early termination with high survival rate"""
+        # Create test mutant files
+        mutant_contents = {
+            "mutant1.py": "# Mutant 1 content",
+            "mutant2.py": "# Mutant 2 content",
+            "mutant3.py": "# Mutant 3 content",
+            "mutant4.py": "# Mutant 4 content",
+            "mutant5.py": "# Mutant 5 content",
+            "mutant6.py": "# Mutant 6 content",
+            "mutant7.py": "# Mutant 7 content",
+            "mutant8.py": "# Mutant 8 content",
+            "mutant9.py": "# Mutant 9 content",
+            "mutant10.py": "# Mutant 10 content"
+        }
+        
+        for name, content in mutant_contents.items():
+            with open(os.path.join(self.test_dir, name), "w") as f:
+                f.write(content)
+
+        # Run analysis with a command that always "survives"
+        killed, not_killed = analyze(
+            self.test_dir,
+            command="exit 0",  # Command that always succeeds, thus mutants "survive"
+            timeout=1,
+            survival_threshold=0.3,
+        )
+        
+        self.assertLess(len(killed), len(mutant_contents))
+        self.assertGreater(len(not_killed), 0)
+
+    def test_empty_folder(self):
+        """Test behavior with empty input directory"""
+        with self.assertRaises(Exception) as context:
+            analyze(self.test_dir)
+
+        self.assertEqual(
+           str(context.exception),
+            f'No mutants on the provided folder path ({self.test_dir})'
+        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR proposes a new parameter called survivor threshold. With it, the user can set a maximum survivor rate so the program stops running after that survival rate is exceeded.

It also provides new tests for the analyze() function, checking for empty files for example. 

@kiocosta and I have worked on this PR but have not tested using the Bitcoin Core yet. 

Closes #7 